### PR TITLE
Only remove left padding above desktop size

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4,8 +4,10 @@ body {
 aside, main {
   padding: 10px!important;
 }
-main {
-  padding-left: 0!important;
+@media (min-width: 992px) {
+  main {
+    padding-left: 0!important;
+  }
 }
 aside .inner, main .inner {
   background: #fff;


### PR DESCRIPTION
Currently when reducing to below desktop sizing the application will vertically stack the About above the main section.

The main section has a 10px left padding to create space when horizontally aligned that should not be there when vertically aligned.

![image](https://cloud.githubusercontent.com/assets/13903378/13171017/7c462f74-d744-11e5-914e-30fb13fe2cc2.png)

@freaksauce 
